### PR TITLE
Add professional multi-page website

### DIFF
--- a/abstracts.html
+++ b/abstracts.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Robinson Vidva - Presentations</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.html">Robinson Vidva</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav ms-auto">
+        <li class="nav-item"><a class="nav-link" href="resume.html">Resume</a></li>
+        <li class="nav-item"><a class="nav-link" href="publications.html">Publications</a></li>
+        <li class="nav-item"><a class="nav-link" href="abstracts.html">Presentations</a></li>
+        <li class="nav-item"><a class="nav-link" href="patents.html">Patents</a></li>
+        <li class="nav-item"><a class="nav-link" href="certifications.html">Certifications</a></li>
+      </ul>
+    </div>
+  </div>
+</nav>
+<header class="bg-secondary text-white text-center py-5">
+  <div class="container">
+    <h1 class="display-4">Abstracts &amp; Conference Presentations</h1>
+  </div>
+</header>
+<div class="container my-4">
+  <ul>
+    <li><strong>AraC-Daunorubicin-Etoposide (ADE) Response Prediction in Pediatric AML Patients Using a Computational Biology Modeling (CBM) Based Precision Medicine Workflow.</strong> Nov 29, 2018. Cogle, C. R., Abbasi, T., Singh, N. K., Sauban, M., Raman, R. K., Vidva, R., Tyagi, A., Talawdekar, A. A., Das, A., Kornblau, S. M., Hoff, F. W., Horton, T. M., &amp; Vali, S. doi:10.1182/blood-2018-99-115775</li>
+    <li><strong>Predicting Response to Dasatinib Using a Computational Model and Its Validation: A Beat AML Project Study.</strong> Nov 29, 2018. Tyner, J. W., Druker, B. J., Tognon, C. E., Kurtz, S. E., Drusbosky, L. M., Sahu, D., Vidva, R., Kapoor, S., Azam, H., Kumar, R., Chickdipatti, P. G., Raveendaran, N. T., Gopi, R. P., Abbasi, T., Vali, S., &amp; Cogle, C. R. doi:10.1182/blood-2018-99-115678</li>
+    <li><strong>Predicting Response to BET Inhibitor in Combination with Palbociclib/Sorafenib Using a Computational Model and Its Validation: A Beat AML Project Study.</strong> Nov 29, 2018. Tyner, J. W., Druker, B. J., Kurtz, S. E., Tognon, C. E., Drusbosky, L. M., Vidva, R., Narvekar, Y., Agrawal, A. K., Gera, S., Prasad, S. A., Shyamasundar, V. P., Tunwer, G. S., Abbasi, T., Vali, S., &amp; Cogle, C. R. doi:10.1182/blood-2018-99-115284</li>
+    <li><strong>Predicting Response to CDK4/6 Inhibitors and Combinations Using a Computational Biology Model and Its Validation: A Beat AML Project Study.</strong> Dec 7, 2017. Drusbosky, L. M., Turcotte, M., Castillo, P., Vidva, R., Gera, S., Sauban, M., Bhargav, P., Deep, P., Kapoor, S., Abbasi, T., Vali, S., Tognon, C. E., Kurtz, S. E., Tyner, J. W., Druker, B. J., &amp; Cogle, C. R. https://www.sciencedirect.com/science/article/pii/S0006497119844257</li>
+    <li><strong>Predicting Response to BET Inhibitors Using a Computational Model and Its Validation: A Beat AML Project Study.</strong> Dec 7, 2017. Drusbosky, L. M., Vidva, R., Gera, S., Lakshminarayana, A. V., Shyamasundar, V. P., Agrawal, A. K., Talawdekar, A., Abbasi, T., Vali, S., Tognon, C. E., Kurtz, S. E., Tyner, J. W., Druker, B. J., &amp; Cogle, C. R. https://www.sciencedirect.com/science/article/pii/S0006497119844245</li>
+    <li><strong>Predicting Response to IDH1/IDH2 Inhibitors Beyond IDH Mutations Using a Computational Model and Its Validation: A Beat AML Project Study.</strong> Dec 7, 2017. Drusbosky, L. M., Vidva, R., Gera, S., Das, A., Tiwari, K. K., Joseph, V., Mohapatra, S., Lunkad, N., Abbasi, T., Vali, S., Tognon, C. E., Kurtz, S. E., Tyner, J. W., Druker, B. J., &amp; Cogle, C. R. https://www.sciencedirect.com/science/article/pii/S0006497119844233</li>
+    <li><strong>A Genomic Signature Predicting Venetoclax Treatment Response in AML Identified By Protein Network Mapping and Validated By Ex Vivo Drug Sensitivity Testing: A Beat AML Project Study.</strong> Dec 2, 2016. Drusbosky, L., Abbasi, T., Vali, S., Radhakrishnan, S., Kumar Singh, N., Usmani, S., Parashar, D., Vidva, R., Druker, B. J., Tognon, C. E., Lo, P., Tyner, J. W., &amp; Cogle, C. R. doi:10.1182/blood.V128.22.1713.1713</li>
+    <li><strong>A Predictive Model of an Oral Inflammatory Response</strong> Mar 22, 2014. Fischer, C., Abbasi, T., Vali, S., Nair, P., Vidva, R., Tiwari, K., &amp; Brogden, K. A. https://iadr.abstractarchives.com/abstract/43am-184905/a-predictive-model-of-an-oral-inflammatory-response</li>
+    <li><strong>HBD3 Both Enhances, Attenuates Dendritic Cell MAPK Responses to HagB.</strong> Mar 23, 2013. Harvey, L., Recker, E., Raina, M., Radhakrishnan, S., Prasad, S., Vidva, R., Cavanaugh, J., Vali, S., &amp; Brogden, K. A. https://iadr.abstractarchives.com/abstract/13iags-173181/hbd3-both-enhances-attenuates-dendritic-cell-mapk-responses-to-hagb</li>
+    <li><strong>Predictive Software-Based Mathematical Modeling: A Novel Approach to Development of Oral Therapies for Rheumatoid Arthritis – Validation in a Murine Collagen Induced Arthritis Model</strong> Nov 12, 2012. Singh, G., Vidva, R., Nair, P., Radhakrishnan, S., Fernandes, P., Abbasi, T., Refino, C., Cruz, J. D., &amp; Vali, S. https://acrabstracts.org/abstract/predictive-software-based-mathematical-modeling-a-novel-approach-to-development-of-oral-therapies-for-rheumatoid-arthritis-validation-in-a-murine-collagen-induced-arthritis-model/</li>
+    <li><strong>Predictive Software-Based Mathematical Modeling: A Novel Approach to Development of Oral Therapies for Rheumatoid Arthritis – Validation in a Murine Collagen Induced Arthritis Model.</strong> Nov 12, 2012. Vali, S., Refino, C., Cruz, J. D., Vidva, R., Nair, P., Radhakrishnan, S., Fernandes, P., Abbasi, T., &amp; Singh, G. https://acrabstracts.org/abstract/novel-combination-therapy-of-existing-repurposed-therapies-designed-by-predictive-software-modeling-shows-profound-impact-on-disease-progression-in-a-murine-collagen-induced-arthritis-model/</li>
+    <li><strong>Insights into the Anti-inflammatory Action of the Soluble Epoxide Hydrolase Inhibitor through Systems Biology based in silico Modeling Approach.</strong> Mar 1, 2008. Vali, S., Hegedus, C., Bhattacharjee, C., Vidva, R., Schmelzer, K., Inceoglu, B., &amp; Hammock, B. D. doi:10.1096/fasebj.22.1_supplement.479.13</li>
+  </ul>
+</div>
+<footer class="bg-light text-center py-3">
+  &copy; 2025 Robinson Vidva
+</footer>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/certifications.html
+++ b/certifications.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Robinson Vidva - Certifications</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.html">Robinson Vidva</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav ms-auto">
+        <li class="nav-item"><a class="nav-link" href="resume.html">Resume</a></li>
+        <li class="nav-item"><a class="nav-link" href="publications.html">Publications</a></li>
+        <li class="nav-item"><a class="nav-link" href="abstracts.html">Presentations</a></li>
+        <li class="nav-item"><a class="nav-link" href="patents.html">Patents</a></li>
+        <li class="nav-item"><a class="nav-link" href="certifications.html">Certifications</a></li>
+      </ul>
+    </div>
+  </div>
+</nav>
+<header class="bg-secondary text-white text-center py-5">
+  <div class="container">
+    <h1 class="display-4">Certifications &amp; Training</h1>
+  </div>
+</header>
+<div class="container my-4">
+  <h2>Certifications</h2>
+  <ul>
+    <li>WGU Certificate: Advanced Data Modeling - Western Governors University, Issued on: Dec 5, 2024</li>
+    <li>WGU Certificate: Data Analytics Fundamentals - Western Governors University, Issued on: Oct 4, 2024</li>
+    <li>WGU Certificate: Data Preparation - Western Governors University, Issued on: Aug 15, 2024</li>
+  </ul>
+  <h2>Online Training Courses</h2>
+  <ul>
+    <li>Cancer Biology - Specialization</li>
+    <li>Basic Principles of Cell Signaling</li>
+    <li>Genomic and Precision Medicine</li>
+    <li>Drug Development Product Management - Specialization</li>
+    <li>BIOX-201-01x: Demystifying Biomedical Big Data</li>
+    <li>Fundamentals of Immunology: Complement, MHC I and II, T Cells, and Cytokines</li>
+    <li>Immunology: Adaptive Immune System</li>
+    <li>Immunology: Innate Immune System</li>
+    <li>Design and Interpretation of Clinical Trials</li>
+    <li>Fundamentals of Immunology: Innate Immunity and B-Cell Function</li>
+    <li>Traditional herbal medicine in supportive cancer care: From alternative to integrative</li>
+    <li>Advanced Course on Biotechnology and Intellectual Property</li>
+  </ul>
+</div>
+<footer class="bg-light text-center py-3">
+  &copy; 2025 Robinson Vidva
+</footer>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -3,69 +3,54 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Robinson Vidva - Portfolio</title>
-  <style>
-    body { font-family: Arial, sans-serif; margin: 0; padding: 0; line-height: 1.6; }
-    header { background: #333; color: #fff; padding: 1rem 0; text-align: center; }
-    section { padding: 20px; max-width: 800px; margin: auto; }
-    h1, h2 { margin-top: 0; }
-    .contact a { color: #333; text-decoration: none; }
-    .contact a:hover { text-decoration: underline; }
-    footer { text-align: center; padding: 1rem 0; background: #f4f4f4; }
-  </style>
+  <title>Robinson Vidva - Computational Biologist</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
-  <header>
-    <h1>Robinson Vidva</h1>
-    <p>Computational Biologist</p>
-  </header>
-
-  <section class="contact">
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.html">Robinson Vidva</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav ms-auto">
+        <li class="nav-item"><a class="nav-link" href="resume.html">Resume</a></li>
+        <li class="nav-item"><a class="nav-link" href="publications.html">Publications</a></li>
+        <li class="nav-item"><a class="nav-link" href="abstracts.html">Presentations</a></li>
+        <li class="nav-item"><a class="nav-link" href="patents.html">Patents</a></li>
+        <li class="nav-item"><a class="nav-link" href="certifications.html">Certifications</a></li>
+      </ul>
+    </div>
+  </div>
+</nav>
+<header class="bg-primary text-white text-center py-5">
+  <div class="container">
+    <h1 class="display-4">Robinson Vidva</h1>
+    <p class="lead">Computational Biologist</p>
+  </div>
+</header>
+<div class="container my-4">
+  <section class="mb-4">
     <h2>Contact</h2>
-    <p>Email: <a href="mailto:robinson.vidva@gmail.com">robinson.vidva@gmail.com</a></p>
-    <p>Phone: (551) 247-2805</p>
-    <p>LinkedIn: <a href="https://www.linkedin.com/in/robinson-vidva/">linkedin.com/in/robinson-vidva</a></p>
-    <p>Location: Washington, DC, USA</p>
+    <ul class="list-unstyled">
+      <li><strong>Email:</strong> <a href="mailto:robinson.vidva@gmail.com">robinson.vidva@gmail.com</a></li>
+      <li><strong>Phone:</strong> (551) 247-2805</li>
+      <li><strong>LinkedIn:</strong> <a href="https://www.linkedin.com/in/robinson-vidva/">linkedin.com/in/robinson-vidva</a></li>
+      <li><strong>Location:</strong> Washington, DC, USA</li>
+    </ul>
   </section>
-
-  <section>
+  <section class="mb-4">
     <h2>Summary</h2>
-    <p>Computational Biologist with over 18 years of experience in bioinformatics, immunology, neuroscience, oncology and drug discovery. Skilled in biological data analytics and biomodel development with expertise in Python, R, SQL, MATLAB and more.</p>
+    <p>Computational Biologist with over 18 years of experience in bioinformatics, immunology, neuroscience, oncology, and drug discovery, specializing in computational biomodel development and biological data analytics. Extensive expertise in big data analytics has contributed to 7 publications, 12 abstracts, 2 patent grants, and 130+ citations. Proficient in various programming languages and tools, including Python, R, SQL, MATLAB, Tableau, C, C++, HTML/CSS/JS, PHP, and Unix shell. Skilled in data modeling, machine learning, and deep learning algorithms, with a strong foundation in implementing innovative solutions. Proven track record in team management, collaboration, problem-solving, and decision-making to advance computational biology and biological data analysis innovation.</p>
   </section>
-
   <section>
-    <h2>Key Achievements</h2>
-    <ul>
-      <li>Analyzed biological data across multiple disease areas resulting in publications and patents.</li>
-      <li>Developed computational pathway models for autoimmune diseases.</li>
-      <li>Created cancer drug therapeutic models validated with cell line and patient datasets.</li>
-    </ul>
+    <a href="resume.html" class="btn btn-primary">View Full Resume</a>
   </section>
-
-  <section>
-    <h2>Education</h2>
-    <ul>
-      <li><strong>MS, Data Analytics</strong> - Western Governors University (2024-2025)</li>
-      <li><strong>MBA, Project Management</strong> - Sikkim Manipal University (2012-2020)</li>
-      <li><strong>B.Tech., Biotechnology</strong> - Bharathidasan University (2003-2007)</li>
-    </ul>
-  </section>
-
-  <section>
-    <h2>Recent Experience</h2>
-    <p><strong>Research Technician</strong>, Children's National Hospital (2025-Present)</p>
-    <p>Integrated multi-omics analysis using Python and R to study neurodevelopmental deficits in preterm birth.</p>
-    <p><strong>Founder & Computational Biologist</strong>, Digirobi Solutions (2019-2022)</p>
-    <p>Developed computational models for neuropathway analysis and cancer genomics leading to a patent and publication.</p>
-  </section>
-
-  <section>
-    <h2>Skills</h2>
-    <p>Python, R, MATLAB, SQL, C/C++, HTML/CSS/JS, Tableau, AWS, Project Management and more.</p>
-  </section>
-
-  <footer>
-    <p>&copy; 2025 Robinson Vidva</p>
-  </footer>
+</div>
+<footer class="bg-light text-center py-3">
+  &copy; 2025 Robinson Vidva
+</footer>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/patents.html
+++ b/patents.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Robinson Vidva - Patents</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.html">Robinson Vidva</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav ms-auto">
+        <li class="nav-item"><a class="nav-link" href="resume.html">Resume</a></li>
+        <li class="nav-item"><a class="nav-link" href="publications.html">Publications</a></li>
+        <li class="nav-item"><a class="nav-link" href="abstracts.html">Presentations</a></li>
+        <li class="nav-item"><a class="nav-link" href="patents.html">Patents</a></li>
+        <li class="nav-item"><a class="nav-link" href="certifications.html">Certifications</a></li>
+      </ul>
+    </div>
+  </div>
+</nav>
+<header class="bg-secondary text-white text-center py-5">
+  <div class="container">
+    <h1 class="display-4">Patents</h1>
+  </div>
+</header>
+<div class="container my-4">
+  <ul>
+    <li><strong>Use of scientifically matched plant supplements combined with antineoplastic compounds for the treatment of hematological malignancies.</strong> Patent No. US11478444B2 [Granted] - Oct 25, 2022. Vali, S., Abbasi, T., Stopka, T., Minarik, L., Singh, N. K., Usmani, S., Radhakrishnan, S., Sikora, H., Vidva, R., &amp; Pimkova, K. https://patents.google.com/patent/US11478444B2/</li>
+    <li><strong>Combination of nelfinavir, metformin and rosuvastatin for treating cancer caused by aberrations in PTEN/TP53.</strong> Patent No. US10098880B2 [Granted] - Oct 16, 2018. Vali, S., Usmani, S., Sultana, Z., Kumar, A., Abbasi, T., &amp; Vidva, R. https://patents.google.com/patent/US10098880B2/</li>
+    <li><strong>System and method for development of therapeutic solutions.</strong> Patent No. US20150302167A1 [Published] - Oct 22, 2015. Vali, S., Abbasi, T., Fernandes, P., Rajagopalan, S., Alam, A., Vidva, R., Nair, P. R., Kapoor, S., Radhakrishnan, S., Sultana, Z., Ramanujan, K. S., Tiwari, K. K., Kumar, A., Singh, N. K., Agrawal, A. K., Talawdekar, A. A., Usmani, S., &amp; Singh, R. https://patents.google.com/patent/US20150302167A1/</li>
+    <li><strong>Compositions, process of preparation of said compositions and method of treating inflammatory diseases.</strong> Patent No. US20150098993A1 [Published] - Apr 9, 2015. Vali, S., Vidva, R., Nair, P. R., Fernandes, P., Abbasi, T., &amp; Radhakrishnan, S. https://patents.google.com/patent/US20150098993A1/</li>
+    <li><strong>Compositions, process of preparation of said compositions and method of treating inflammatory diseases.</strong> Patent No. US20140127295A1 [Published] - May 8, 2014. Vali, S., Vidva, R., Nair, P. R., Fernandes, P., Abbasi, T., &amp; Radhakrishnan, S. https://patents.google.com/patent/US20140127295A1/</li>
+  </ul>
+</div>
+<footer class="bg-light text-center py-3">
+  &copy; 2025 Robinson Vidva
+</footer>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/publications.html
+++ b/publications.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Robinson Vidva - Publications</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.html">Robinson Vidva</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav ms-auto">
+        <li class="nav-item"><a class="nav-link" href="resume.html">Resume</a></li>
+        <li class="nav-item"><a class="nav-link" href="publications.html">Publications</a></li>
+        <li class="nav-item"><a class="nav-link" href="abstracts.html">Presentations</a></li>
+        <li class="nav-item"><a class="nav-link" href="patents.html">Patents</a></li>
+        <li class="nav-item"><a class="nav-link" href="certifications.html">Certifications</a></li>
+      </ul>
+    </div>
+  </div>
+</nav>
+<header class="bg-secondary text-white text-center py-5">
+  <div class="container">
+    <h1 class="display-4">Publications</h1>
+  </div>
+</header>
+<div class="container my-4">
+  <ul>
+    <li><strong>Eph/Ephrin-Mediated Immune Modulation: A Potential Therapeutic Target for Skin Cancer.</strong> April 21, 2025. Giannopoulos, K., Karikis, I., Byrd, C., Sanidas, G., Wolff, N., Triantafyllou, M., Simonti, G., Vidva, R., Koutroulis, I., Theocharis, S. and Kratimenos, P. doi:10.1101/2024.08.10.607395</li>
+    <li><strong>MyVivarium: A cloud-based lab animal colony management application with realtime ambient sensing.</strong> Feb 1, 2025. Vidva, R., Raza, M.A., Prabhakaran, J., Sheikh, A., Sharp, A., Ott, H., Moore, A., Fleisher, C., Netherton, H., Goldstein, E. and Pitychoutis, P.M. doi:10.1101/2024.08.10.607395</li>
+    <li><strong>Computational analysis of cortical neuronal excitotoxicity in a large animal model of neonatal brain injury.</strong> Mar 29, 2022. Kratimenos, P., Vij, A., Vidva, R., Koutroulis, I., Delivoria-Papadopoulos, M., Gallo, V., &amp; Sathyanesan, A. doi:10.1186/s11689-022-09431-3</li>
+    <li><strong>Computational Models Accurately Predict Multi-Cell Biomarker Profiles in Inflammation and Cancer.</strong> Jul 26, 2019. Fischer, C. L., Bates, A. M., Lanzel, E. A., Guthmiller, J. M., Johnson, G. K., Singh, N. K., Kumar, A., Vidva, R., Abbasi, T., Vali, S., Xie, X. J., Zeng, E., &amp; Brogden, K. A. doi:10.1038/s41598-019-47381-4</li>
+    <li><strong>Predicting response to BET inhibitors using computational modeling: A BEAT AML project study.</strong> Jan 7, 2019. Drusbosky, L. M., Vidva, R., Gera, S., Lakshminarayana, A. V., Shyamasundar, V. P., Agrawal, A. K., Talawdekar, A., Abbasi, T., Vali, S., Tognon, C. E., Kurtz, S. E., Tyner, J. W., McWeeney, S. K., Druker, B. J., &amp; Cogle, C. R. doi:10.1016/j.leukres.2018.11.010</li>
+    <li><strong>Histatin 5 binds to Porphyromonas gingivalis hemagglutinin B (HagB) and alters HagB-induced chemokine responses.</strong> Jan 29, 2014. Borgwardt, D. S., Martin, A. D., Van Hemert, J. R., Yang, J., Fischer, C. L., Recker, E. N., Nair, P. R., Vidva, R., Chandrashekaraiah, S., Progulske-Fox, A., Drake, D., Cavanaugh, J. E., Vali, S., Zhang, Y., &amp; Brogden, K. A. doi:10.1038/srep03904</li>
+    <li><strong>Defensin DEFB103 bidirectionally regulates chemokine and cytokine responses to a pro-inflammatory stimulus.</strong> Feb 6, 2013. Harvey, L. E., Kohlgraf, K. G., Mehalick, L. A., Raina, M., Recker, E. N., Radhakrishnan, S., Prasad, S. A., Vidva, R., Progulske-Fox, A., Cavanaugh, J. E., Vali, S., &amp; Brogden, K. A. doi:10.1038/srep01232</li>
+  </ul>
+</div>
+<footer class="bg-light text-center py-3">
+  &copy; 2025 Robinson Vidva
+</footer>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/resume.html
+++ b/resume.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Robinson Vidva - Resume</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.html">Robinson Vidva</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav ms-auto">
+        <li class="nav-item"><a class="nav-link" href="resume.html">Resume</a></li>
+        <li class="nav-item"><a class="nav-link" href="publications.html">Publications</a></li>
+        <li class="nav-item"><a class="nav-link" href="abstracts.html">Presentations</a></li>
+        <li class="nav-item"><a class="nav-link" href="patents.html">Patents</a></li>
+        <li class="nav-item"><a class="nav-link" href="certifications.html">Certifications</a></li>
+      </ul>
+    </div>
+  </div>
+</nav>
+<header class="bg-secondary text-white text-center py-5">
+  <div class="container">
+    <h1 class="display-4">Resume</h1>
+  </div>
+</header>
+<div class="container my-4">
+  <section class="mb-5">
+    <h2>Summary</h2>
+    <p>Computational Biologist with over 18 years of experience in bioinformatics, immunology, neuroscience, oncology, and drug discovery, specializing in computational biomodel development and biological data analytics. Extensive expertise in big data analytics has contributed to 7 publications, 12 abstracts, 2 patent grants, and 130+ citations. Proficient in various programming languages and tools, including Python, R, SQL, MATLAB, Tableau, C, C++, HTML/CSS/JS, PHP, and Unix shell. Skilled in data modeling, machine learning, and deep learning algorithms, with a strong foundation in implementing innovative solutions. Proven track record in team management, collaboration, problem-solving, and decision-making to advance computational biology and biological data analysis innovation.</p>
+  </section>
+  <section class="mb-5">
+    <h2>Key Achievements</h2>
+    <ul>
+      <li>Analyzed biological data in immunology, neuroscience and oncology, resulting in publications and patents. Collaborated on drug repurposing strategies, leading to patents.</li>
+      <li>Developed comprehensive pathway models, ranging from single-cell to multi-cell type systems, to represent autoimmune diseases such as rheumatoid arthritis.</li>
+      <li>Developed cancer drug therapeutic models and validated them using cancer cell line and patient datasets, enhancing the accuracy of precision medicine approaches.</li>
+    </ul>
+  </section>
+  <section class="mb-5">
+    <h2>Education</h2>
+    <ul>
+      <li><strong>Master of Science (MS) - Data Analytics</strong>, Western Governors University (07/2024 - 01/2025), United States</li>
+      <li><strong>Master of Business Administration (MBA) - Project Management</strong>, Sikkim Manipal University (11/2012 - 02/2020), India</li>
+      <li><strong>Bachelor of Technology (B.Tech.) - Biotechnology</strong>, Bharathidasan University (07/2003 - 04/2007), India</li>
+    </ul>
+  </section>
+  <section class="mb-5">
+    <h2>Work Experience</h2>
+    <h3>Research Technician, <a href="https://www.childrensnational.org">Children's National Hospital</a> (03/2025 - Ongoing)</h3>
+    <ul>
+      <li>Integrated multi-omics analyses (bulk RNA-seq, metabolomics, genomics) across mouse and human datasets using Python, R, and SQL to uncover DEGs, enriched pathways, and GO terms underlying preterm birth-associated neurodevelopmental deficits and related conditions including NEC, SAE, and SIDS.</li>
+      <li>Applied DeepLabCut, BSOID, and custom Python scripts to analyze 3-chamber behavioral assays in mouse models, quantifying how physical therapy and environmental enrichment (EE) interventions impact neurodevelopmental outcomes in preterm birth research.</li>
+      <li>Built ML and statistical models to analyze Erasmus Ladder motor coordination data, identifying significant gait and cerebellar deficits in preterm models. Created visualizations to highlight motor learning impairments and sensorimotor integration patterns.</li>
+      <li>Analyzed neonatal growth data using Fenton charts, performing statistical analysis and data cleaning to track developmental trajectories in preterm infants. Created visualizations to communicate growth patterns and key clinical findings.</li>
+    </ul>
+    <h3>Founder and Computational Biologist, <a href="https://www.digirobi.com/">Digirobi Solutions</a> (09/2019 - 06/2022)</h3>
+    <ul>
+      <li>Developed a computational biology model for neuropathway analysis using MATLAB, leading to 1 publication on the data and enhanced understanding of molecular mechanisms.</li>
+      <li>Analyzed cancer genomics data and developed a web-based workflow, securing 1 patent for a nutraceutical combination aimed at enhancing cancer therapies.</li>
+      <li>Co-developed MyVivarium, an open-source cloud app for affordable, real-time research animal colony management, resulting in 1 publication.</li>
+      <li>Provided project-to-product management support and implemented business intelligence strategies to improve business performance for 3+ businesses.</li>
+    </ul>
+    <h3>Senior Lead Scientist, <a href="https://cellworks.life/">Cellworks Research India Private Limited</a> (06/2007 - 09/2019)</h3>
+    <ul>
+      <li>Developed molecular biology and cell signaling models, including TNF, Interleukin, and metabolism pathways, improving understanding of disease mechanisms.</li>
+      <li>Specialized in computational modeling in immunology, focusing on cell signaling and pathway models for autoimmune diseases, including rheumatoid arthritis.</li>
+      <li>Developed a comprehensive autoimmune disease model involving 8 cell types, validated with in-vivo data, contributing to 3 publications and 5 conference abstracts on immunology and skin related autoimmune diseases.</li>
+      <li>Managed teams of 10+ members, leading projects in data analytics, computational biology, and research development to improve decision-making through advanced analytics.</li>
+      <li>Built cancer drug/therapeutic models and developed a genomics database with 500+ cancer cell lines and TCGA and MSK datasets. This work contributed to 1 publication on leukemia genomics and 7 ASH abstracts, enhancing precision medicine by aligning drug responses with cancer genomics.</li>
+      <li>Secured 1 approved patent on cancer drug repurposing, 2 patent applications for novel repurposed drugs for RA, and 1 process patent application on drug repurposing methodology.</li>
+      <li>Led 25+ training sessions for team development, focusing on enhancing computational biology & data analytics in research data.</li>
+    </ul>
+  </section>
+  <section class="mb-5">
+    <h2>Skills</h2>
+    <h4>Science</h4>
+    <ul>
+      <li>Mathematical Modeling</li>
+      <li>Computational Biology</li>
+      <li>Immunology</li>
+      <li>Bioinformatics</li>
+      <li>Cell Biology</li>
+      <li>Statistics</li>
+      <li>Cancer Biology</li>
+      <li>Cancer Therapeutics</li>
+      <li>Molecular Biology</li>
+      <li>Genetics</li>
+      <li>Genomics</li>
+      <li>Precision Medicine</li>
+      <li>Drug Discovery</li>
+      <li>Predictive Modeling</li>
+      <li>Systems Biology</li>
+      <li>Clinical Study Design</li>
+      <li>Patent Analysis</li>
+      <li>Herbal Medicine</li>
+      <li>Cell Signaling</li>
+      <li>Data Mining</li>
+      <li>Data Cleaning</li>
+      <li>Data Analysis</li>
+      <li>Presentation</li>
+      <li>Data Visualization</li>
+    </ul>
+    <h4>Programming &amp; Tools</h4>
+    <ul>
+      <li>Python</li>
+      <li>PHP</li>
+      <li>SQL</li>
+      <li>R</li>
+      <li>C</li>
+      <li>C++</li>
+      <li>HTML/CSS/JS</li>
+      <li>Linux Shell</li>
+      <li>MATLAB</li>
+      <li>Tableau</li>
+      <li>VS Code</li>
+      <li>AWS</li>
+    </ul>
+    <h4>Management</h4>
+    <ul>
+      <li>Project Management</li>
+      <li>Project Quality Control</li>
+      <li>Leadership</li>
+      <li>Data-Driven Decision-making</li>
+      <li>Storytelling</li>
+    </ul>
+  </section>
+</div>
+<footer class="bg-light text-center py-3">
+  &copy; 2025 Robinson Vidva
+</footer>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- revamp single page into multi-page Bootstrap site
- add resume, publications, presentations, patents and certifications pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68821a0398fc8333a098b8ba75d8006a