### PR TITLE
Add CV highlights to home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,14 +40,54 @@
       <li><strong>Location:</strong> Washington, DC, USA</li>
     </ul>
   </section>
-  <section class="mb-4">
-    <h2>Summary</h2>
-    <p>Computational Biologist with over 18 years of experience in bioinformatics, immunology, neuroscience, oncology, and drug discovery, specializing in computational biomodel development and biological data analytics. Extensive expertise in big data analytics has contributed to 7 publications, 12 abstracts, 2 patent grants, and 130+ citations. Proficient in various programming languages and tools, including Python, R, SQL, MATLAB, Tableau, C, C++, HTML/CSS/JS, PHP, and Unix shell. Skilled in data modeling, machine learning, and deep learning algorithms, with a strong foundation in implementing innovative solutions. Proven track record in team management, collaboration, problem-solving, and decision-making to advance computational biology and biological data analysis innovation.</p>
-  </section>
-  <section>
-    <a href="resume.html" class="btn btn-primary">View Full Resume</a>
-  </section>
-</div>
+    <section class="mb-4">
+      <h2>Summary</h2>
+      <p>Computational Biologist with over 18 years of experience in bioinformatics, immunology, neuroscience, oncology, and drug discovery, specializing in computational biomodel development and biological data analytics. Extensive expertise in big data analytics has contributed to 7 publications, 12 abstracts, 2 patent grants, and 130+ citations. Proficient in various programming languages and tools, including Python, R, SQL, MATLAB, Tableau, C, C++, HTML/CSS/JS, PHP, and Unix shell. Skilled in data modeling, machine learning, and deep learning algorithms, with a strong foundation in implementing innovative solutions. Proven track record in team management, collaboration, problem-solving, and decision-making to advance computational biology and biological data analysis innovation.</p>
+    </section>
+    <section class="mb-4">
+      <h2>Work Experience</h2>
+      <div class="row">
+        <div class="col-md-4 mb-3">
+          <div class="card h-100">
+            <div class="card-body">
+              <h5 class="card-title">Research Technician</h5>
+              <h6 class="card-subtitle mb-2 text-muted">Children's National Hospital, 2025–Present</h6>
+              <p class="card-text">Integrated multi-omics data and built ML models to study preterm birth neurodevelopment.</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-4 mb-3">
+          <div class="card h-100">
+            <div class="card-body">
+              <h5 class="card-title">Founder &amp; Computational Biologist</h5>
+              <h6 class="card-subtitle mb-2 text-muted">Digirobi Solutions, 2019–2022</h6>
+              <p class="card-text">Developed computational biology models and a nutraceutical patent for cancer therapies.</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-4 mb-3">
+          <div class="card h-100">
+            <div class="card-body">
+              <h5 class="card-title">Senior Lead Scientist</h5>
+              <h6 class="card-subtitle mb-2 text-muted">Cellworks Research India, 2007–2019</h6>
+              <p class="card-text">Built autoimmune and oncology models and guided teams of over ten researchers.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="mb-4">
+      <h2>Education</h2>
+      <ul class="list-group">
+        <li class="list-group-item"><strong>MS, Data Analytics</strong>, Western Governors University (2024–2025)</li>
+        <li class="list-group-item"><strong>MBA, Project Management</strong>, Sikkim Manipal University (2012–2020)</li>
+        <li class="list-group-item"><strong>B.Tech., Biotechnology</strong>, Bharathidasan University (2003–2007)</li>
+      </ul>
+    </section>
+    <section>
+      <a href="resume.html" class="btn btn-primary">View Full Resume</a>
+    </section>
+  </div>
 <footer class="bg-light text-center py-3">
   &copy; 2025 Robinson Vidva
 </footer>


### PR DESCRIPTION
## Summary
- Expand landing page with work experience and education sections drawn from CV

## Testing
- `tidy -q -e index.html` *(fails: command not found)*
- `python -m py_compile $(git ls-files '*.py')` *(fails: the following arguments are required: filenames)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d5ed68cc8333a99e2af3503ecbd3