### PR TITLE
Fix research page: remove preprints filter and duplicate SFN abstracts

### DIFF
--- a/research.html
+++ b/research.html
@@ -75,7 +75,6 @@
         <div class="filter-buttons">
           <button class="btn btn-primary btn-sm" onclick="filterItems('all', event)">All</button>
           <button class="btn btn-outline-primary btn-sm" onclick="filterItems('publication', event)">Publications</button>
-          <button class="btn btn-outline-primary btn-sm" onclick="filterItems('preprint', event)">Preprints</button>
           <button class="btn btn-outline-primary btn-sm" onclick="filterItems('presentation', event)">Presentations</button>
           <button class="btn btn-outline-primary btn-sm" onclick="filterItems('patent', event)">Patents</button>
         </div>
@@ -121,16 +120,6 @@
       <li class="research-item" data-type="publication" data-year="2025" data-date="2025-02-01">
         <span class="badge badge-publication">Publication</span>
         <strong>MyVivarium: A cloud-based lab animal colony management application with real-time ambient sensing.</strong> Feb 1, 2025. <span class="author-highlight">Vidva, R.</span>, Raza, M.A., Prabhakaran, J., Sheikh, A., Sharp, A., Ott, H., Moore, A., Fleisher, C., Netherton, H., Goldstein, E. and Pitychoutis, P.M. <a href="https://doi.org/10.1016/j.csbj.2025.01.025" target="_blank">doi:10.1016/j.csbj.2025.01.025</a>
-      </li>
-
-      <!-- 2025 Presentations -->
-      <li class="research-item" data-type="presentation" data-year="2025" data-date="2025-11-15">
-        <span class="badge badge-presentation">Presentation</span>
-        <strong>Early postnatal rehabilitation mitigates motor, growth, and social deficits in perinatal brain injury.</strong> Nov 15, 2025. Simonti, G., <span class="author-highlight">Vidva, R.</span>, Sanidas, G., Byrd, C., Lowe, C., Triantafyllou, M., Wolff, N., Chandereng, T., Koutroulis, I., Gallo, V., &amp; Kratimenos, P. Program No. PSTR019.10. 2025 Neuroscience Meeting Planner. San Diego, CA: Society for Neuroscience, 2025. <a href="https://www.abstractsonline.com/pp8/#!/21171/presentation/31850" target="_blank">View abstract</a>
-      </li>
-      <li class="research-item" data-type="presentation" data-year="2025" data-date="2025-11-15">
-        <span class="badge badge-presentation">Presentation</span>
-        <strong>Necrotizing Enterocolitis Selectively Disrupts Pontine Development in the Preterm Brain.</strong> Nov 15, 2025. Sanidas, G., Lowe, C., Byrd, C., <span class="author-highlight">Vidva, R.</span>, Simonti, G., Chandereng, T., Gallo, V., &amp; Kratimenos, P. Program No. PSTR103.21. 2025 Neuroscience Meeting Planner. San Diego, CA: Society for Neuroscience, 2025. <a href="https://www.abstractsonline.com/pp8/#!/21171/presentation/30651" target="_blank">View abstract</a>
       </li>
 
       <!-- 2022 Publications & Patents -->


### PR DESCRIPTION
- Remove non-functional preprints filter button (preprints are publications with secondary tag)
- Remove duplicate 2025 SFN presentation entries that appeared twice