### PR TITLE
Fix share button styling, patent count, and redundant CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Robinson Vidva - Computational Biologist</title>
-  <meta name="description" content="Robinson Vidva - Computational biologist with 18+ years of experience in bioinformatics, multi-omics data analysis, neuroscience, immunology, immuno-oncology, and drug discovery. 7 publications, 14 presentations, 2 patents, 145+ citations.">
+  <meta name="description" content="Robinson Vidva - Computational biologist with 18+ years of experience in bioinformatics, multi-omics data analysis, neuroscience, immunology, immuno-oncology, and drug discovery. 7 publications, 14 presentations, 5 patents, 145+ citations.">
 
   <!-- Favicon -->
   <link rel="icon" type="image/png" sizes="32x32" href="images/Preview.png">
@@ -130,7 +130,7 @@
       </div>
       <div class="metric-divider"></div>
       <div class="metric-item">
-        <span class="metric-number">6</span>
+        <span class="metric-number">5</span>
         <span class="metric-label">Patents</span>
       </div>
       <div class="metric-divider"></div>

--- a/style.css
+++ b/style.css
@@ -166,7 +166,7 @@ section h2 {
   font-weight: 700;
   margin-bottom: 1.75rem;
   padding-bottom: 0.6rem;
-  border-bottom: 3px solid var(--primary-accent);
+  border-bottom: 3px solid;
   border-image: linear-gradient(to right, var(--primary-accent), var(--border-color)) 1;
 }
 
@@ -738,14 +738,14 @@ section p em {
 /* Certification Provider Icons - see .cert-provider below in Certification Cards section */
 
 /* Education Collapse Toggle */
-.education-item .btn-outline-secondary {
+.btn-outline-secondary {
   font-size: 0.85rem;
   color: var(--light-text);
   border-color: var(--border-color);
   transition: all 0.2s ease;
 }
 
-.education-item .btn-outline-secondary:hover {
+.btn-outline-secondary:hover {
   color: var(--primary-accent);
   border-color: var(--primary-accent);
   background-color: transparent;


### PR DESCRIPTION
- Remove .education-item scoping from .btn-outline-secondary so share buttons on article pages receive consistent styling
- Correct patent count from 6 to 5 (matching research page listings)
- Update meta description patent count from 2 to 5
- Clean up redundant border-bottom declaration on section h2

https://claude.ai/code/session_019pjGU6j7Rw163ukMVBgHXC