### PR TITLE
Remove duplicate Acknowledgements section from research page

### DIFF
--- a/research.html
+++ b/research.html
@@ -265,19 +265,6 @@
   </div>
   </section>
 
-  <!-- Acknowledgements -->
-  <section class="mb-5">
-    <h3 class="mb-3" style="font-size: 1.3rem; color: var(--secondary-dark);">Acknowledgements</h3>
-    <p style="font-size: 0.95rem; color: var(--light-text);">Contributions acknowledged in peer-reviewed publications:</p>
-    <ul class="research-list" style="margin-bottom: 0;">
-      <li class="research-item">
-        <span class="badge badge-publication">Publication</span>
-        <strong>A genomics-informed computational biology platform prospectively predicts treatment outcomes in AML.</strong> Jun 20, 2019. Shih, A. H., Betts, C., Yang, F. C., Engstrom, L. D., ..., &amp; Bhagwat, S. V. <em>Blood Advances</em>, 3(12), 1837&ndash;1847. <a href="https://doi.org/10.1182/bloodadvances.2018028316" target="_blank">doi:10.1182/bloodadvances.2018028316</a>
-        <br><small class="text-muted mt-1 d-block"><i class="fas fa-quote-left fa-xs me-1" aria-hidden="true"></i> "The authors thank &hellip; Robinson Vidva for creating the visual abstract and figures."</small>
-      </li>
-    </ul>
-  </section>
-
   <!-- Page Navigation -->
   <div class="text-center mt-5 mb-4">
     <a href="certifications.html" class="btn btn-outline-primary">


### PR DESCRIPTION
The Acknowledgements section already exists on the CV page (cv.html), so it was redundant on the research page (research.html).

https://claude.ai/code/session_012VrsrvRZUbkfYr4F6q1HQK